### PR TITLE
Fix deprecated depends_on macos string comparison format

### DIFF
--- a/Casks/playcover-community.rb
+++ b/Casks/playcover-community.rb
@@ -9,7 +9,7 @@ cask "playcover-community" do
 
   auto_updates true
   depends_on arch: :arm64
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "PlayCover.app"
 

--- a/Casks/playcover-nightly.rb
+++ b/Casks/playcover-nightly.rb
@@ -12,7 +12,7 @@ cask "playcover-nightly" do
   auto_updates true
   conflicts_with cask: "playcover-community"
   depends_on arch: :arm64
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "PlayCover.app"
 


### PR DESCRIPTION
## Summary
Homebrew now warns when casks use the string comparison form of `depends_on macos:`:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :monterey` instead.
```

This updates both affected casks to the supported symbol form:

- `depends_on macos: ">= :monterey"` → `depends_on macos: :monterey`

Per the [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook), `depends_on macos: :monterey` declares Monterey as the **minimum** compatible macOS release (same intent as `">= :monterey"`).

## Changes
- `Casks/playcover-community.rb`
- `Casks/playcover-nightly.rb`

## Test plan
- [ ] `brew style playcover/playcover/playcover-community`
- [ ] Confirm the deprecation warning no longer appears when installing/using the cask